### PR TITLE
Vml get set mode roundtrip

### DIFF
--- a/mkl/_mkl_service.pxd
+++ b/mkl/_mkl_service.pxd
@@ -56,6 +56,9 @@ cdef extern from "mkl.h":
     int MKL_CBWR_AVX2
     int MKL_CBWR_AVX512_MIC
     int MKL_CBWR_AVX512
+    int MKL_CBWR_STRICT
+    int MKL_CBWR_AVX512_E1
+    int MKL_CBWR_AVX512_MIC_E1
     int MKL_CBWR_BRANCH
     int MKL_CBWR_ALL
     int MKL_CBWR_SUCCESS

--- a/mkl/_mkl_service.pyx
+++ b/mkl/_mkl_service.pyx
@@ -850,6 +850,7 @@ cdef object __vml_set_mode(accuracy, ftzdaz, errmode):
             'ftzdaz': {
                 'on': mkl.VML_FTZDAZ_ON,
                 'off': mkl.VML_FTZDAZ_OFF,
+		'default': 0,
             },
             'errmode': {
                 'ignore': mkl.VML_ERRMODE_IGNORE,

--- a/mkl/_mkl_service.pyx
+++ b/mkl/_mkl_service.pyx
@@ -390,12 +390,14 @@ cdef int __python_obj_to_int(obj, func_name):
 
 cdef void __check_positive_num_threads(int p, func_name):
     if p <= 0:
-        warnings.warn("Non-positive argument of " + func_name +  " is being ignored, number of threads will not be changed")
+        warnings.warn("Non-positive argument of " + func_name +
+                      " is being ignored, number of threads will not be changed")
 
 
 cdef void __check_non_negative_num_threads(int p, func_name):
     if p < 0:
-        warnings.warn("Non-positive argument of " + func_name +  " is being ignored, number of threads will not be changed")
+        warnings.warn("Non-positive argument of " + func_name +
+                      " is being ignored, number of threads will not be changed")
 
 
 cdef inline int __mkl_str_to_int(variable, possible_variables_dict):
@@ -404,7 +406,8 @@ cdef inline int __mkl_str_to_int(variable, possible_variables_dict):
     if possible_variables_dict is None:
         raise RuntimeError("Dictionary mapping possible variable value to internal code is missing")
     if variable not in possible_variables_dict:
-        raise ValueError('Variable: <' + str(variable) + '> not in ' + str(possible_variables_dict))
+        raise ValueError('Variable: <' + str(variable) + '> not in ' +
+                         str(possible_variables_dict.keys()))
 
     return possible_variables_dict[variable]
 
@@ -414,7 +417,8 @@ cdef  __mkl_int_to_str(int mkl_int_variable, possible_variables_dict):
         raise RuntimeError("Dictionary mapping possible internal code to output string is missing")
 
     if mkl_int_variable not in possible_variables_dict:
-        raise ValueError('Variable: <' + str(mkl_int_variable) + '> not in ' + str(possible_variables_dict))
+        raise ValueError('Variable: <' + str(mkl_int_variable) + '> not in ' +
+                         str(possible_variables_dict.keys()))
 
     return possible_variables_dict[mkl_int_variable]
 

--- a/mkl/_mkl_service.pyx
+++ b/mkl/_mkl_service.pyx
@@ -275,7 +275,7 @@ cpdef cbwr_set(branch=None):
     return __cbwr_set(branch)
 
 
-cpdef cbwr_get(cnr_const=None):
+cpdef cbwr_get(cnr_const='all'):
     """
     Returns the current CNR settings.
     https://software.intel.com/en-us/mkl-developer-reference-c-mkl-cbwr-get

--- a/mkl/_mkl_service.pyx
+++ b/mkl/_mkl_service.pyx
@@ -653,6 +653,12 @@ cdef object __cbwr_set(branch=None):
             'avx2': mkl.MKL_CBWR_AVX2,
             'avx512_mic': mkl.MKL_CBWR_AVX512_MIC,
             'avx512': mkl.MKL_CBWR_AVX512,
+            'avx512_e1': mkl.MKL_CBWR_AVX512_E1,
+            'avx512_mic_e1': mkl.MKL_CBWR_AVX512_MIC_E1,
+            'avx2,strict': mkl.MKL_CBWR_AVX2 | mkl.MKL_CBWR_STRICT,
+            'avx512_mic,strict': mkl.MKL_CBWR_AVX512_MIC | mkl.MKL_CBWR_STRICT,
+            'avx512,strict': mkl.MKL_CBWR_AVX512 | mkl.MKL_CBWR_STRICT,
+            'avx512_e1,strict': mkl.MKL_CBWR_AVX512_E1 | mkl.MKL_CBWR_STRICT,
         },
         'output': {
             mkl.MKL_CBWR_SUCCESS: 'success',

--- a/tests/test_mkl_service.py
+++ b/tests/test_mkl_service.py
@@ -287,6 +287,10 @@ class test_miscellaneous():
 
 class test_vm_service_functions():
     # https://software.intel.com/en-us/mkl-developer-reference-c-vm-service-functions
+    def test_vml_set_get_mode_roundtrip(self):
+        saved = mkl.vml_get_mode()
+        mkl.vml_set_mode(*saved) # should not raise errors
+
     def test_vml_set_mode_ha_on_ignore(self):
         mkl.vml_set_mode('ha', 'on', 'ignore')
 


### PR DESCRIPTION
Closes #8 , closes #5

```
(b_service) [15:39:18 vmlin mkl-service]$ ipython
Python 3.7.3 (default, Aug  2 2019, 04:21:04) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.7.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import mkl                                                                                                                                                                                                                           

In [2]: mkl.cbwr_set('avx2,strict')                                                                                                                                                                                                          
Out[2]: 'success'

In [4]: mkl.cbwr_get('branch')                                                                                                                                                                                                               
Out[4]: 'avx2'
```

Also 

```
In [5]: saved = mkl.vml_get_mode()                                                                                                                                                                                                           

In [6]: saved                                                                                                                                                                                                                                
Out[6]: ('ha', 'default', 'default')

In [7]: mkl.vml_set_mode(*saved)                                                                                                                                                                                                             
Out[7]: ('ha', 'default', 'default')
```

