### PR TITLE
Conditional mpich2

### DIFF
--- a/mkl/_mkl_service.pxd
+++ b/mkl/_mkl_service.pxd
@@ -91,6 +91,7 @@ cdef extern from "mkl.h":
     int MKL_BLACS_MSMPI
     int MKL_BLACS_INTELMPI
     int MKL_BLACS_MPICH2
+    int MKL_BLACS_LASTMPI
 
     # VML Constants
     int VML_HA

--- a/mkl/_mkl_service.pyx
+++ b/mkl/_mkl_service.pyx
@@ -874,7 +874,6 @@ cdef __set_mpi(vendor, custom_library_name=None):
             'custom': mkl.MKL_BLACS_CUSTOM,
             'msmpi': mkl.MKL_BLACS_MSMPI,
             'intelmpi': mkl.MKL_BLACS_INTELMPI,
-            'mpich2': mkl.MKL_BLACS_MPICH2,
         },
         'output': {
             0: 'success',
@@ -883,6 +882,8 @@ cdef __set_mpi(vendor, custom_library_name=None):
             -3: 'MPI library cannot be set at this point',
         },
     }
+    if mkl.MKL_BLACS_LASTMPI > mkl.MKL_BLACS_INTELMPI + 1:
+        __variables['input']['mpich2'] = mkl.MKL_BLACS_MPICH2
     if ((vendor is 'custom' or custom_library_name is not None) and
         (vendor is not 'custom' or custom_library_name is None)):
         raise ValueError("Selecting custom MPI for BLACS requires specifying "

--- a/mkl/_mkl_service.pyx
+++ b/mkl/_mkl_service.pyx
@@ -31,6 +31,14 @@ import warnings
 cimport mkl._mkl_service as mkl
 
 
+cdef extern from *:
+    """
+    /* defind MKL_BLACS_MPICH2 if undefined */
+    #ifndef MKL_BLACS_MPICH2
+    #define MKL_BLACS_MPICH2 -1
+    #endif
+    """
+
 ctypedef struct MemStatData:
     #  DataAllocatedBytes, AllocatedBuffers
     mkl.MKL_INT64 allocated_bytes


### PR DESCRIPTION
This commit is future proofing `mkl-service` for the possibility of `MKL_BLACS_MPICH2` not being defined on certain platforms.

The change works around this problem my defining the variable to a bogus value (arbitrarily set at -1), and dynamic logic to not use it.