### PR TITLE
Fix wrong directory name for _mkl_service.c in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Cython
-mkl-service/_mkl_service.c
+mkl/_mkl_service.c
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Currently `_mkl_service.c` is not ignored due to the incorrect directory name.