### PR TITLE
Use `windows-latest` in GitHub CI

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -74,7 +74,7 @@ jobs:
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.conda
 
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       matrix:
@@ -203,7 +203,7 @@ jobs:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         experimental: [false]
-        runner: [windows-2019]
+        runner: [windows-latest]
     continue-on-error: ${{ matrix.experimental }}
     env:
       CHANNELS: -c conda-forge -c https://software.repos.intel.com/python/conda --override-channels


### PR DESCRIPTION
`windows-2019` image is no longer supported by GitHub CI runners

this PR switches over workflows that run on Windows to `windows-latest`