### PR TITLE
Use git vars to define the version and build number

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,15 +1,12 @@
-{% set version = "2.6.0dev0" %}
-{% set buildnumber = 0 %}
-
 package:
     name: mkl-service
-    version: {{ version }}
+    version: {{ GIT_DESCRIBE_TAG }}
 
 source:
     path: ..
 
 build:
-    number: {{ buildnumber }}
+    number: {{ GIT_DESCRIBE_NUMBER }}
     script_env:
       - WHEELS_OUTPUT_FOLDER
     ignore_run_exports:


### PR DESCRIPTION
This PR adds the use of `GIT_DESCRIBE_TAG` and `GIT_DESCRIBE_NUMBER` instead of manual input