### PR TITLE
Improve use of `conda-incubator/setup-miniconda` GitHub action for Windows jobs.

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Store conda paths as envs
         shell: bash -el {0}
         run: |
-          echo "CONDA_BLD=C:\\Miniconda\\conda-bld\\win-64\\" >> $GITHUB_ENV
+          echo "CONDA_BLD=$CONDA_PREFIX\\conda-bld\\win-64\\" >> $GITHUB_ENV
           echo "WHEELS_OUTPUT_FOLDER=$GITHUB_WORKSPACE\\" >> $GITHUB_ENV
 
       - name: Build conda package


### PR DESCRIPTION
The PR updates arguments passed to `conda-incubator/setup-miniconda` GitHub action for jobs on Windows OS.
It's now asking the latest version of miniforge and to use mamba explicitly.