### PR TITLE
Backport gh-117

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vtavana @ndgrigorian @antonwolfy @xaleryb @ekomarova
+* @ndgrigorian @antonwolfy @xaleryb @jharlow-intel


### PR DESCRIPTION
This PR backports of #117 from development branch to `maintenance/2.6.x`.