### PR TITLE
Fix security vulnerability: Change HTTP URLs to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+* Changed insecure HTTP URLs to HTTPS in `pyproject.toml` and conda recipe files for improved security
 
 ## [2.7.0] (04/16/2026)
 

--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -40,7 +40,7 @@ test:
       - pytest -vv --pyargs mkl
 
 about:
-    home: http://github.com/IntelPython/mkl-service
+    home: https://github.com/IntelPython/mkl-service
     license: BSD-3-Clause
     license_file: LICENSE.txt
     summary: Python hooks for Intel® oneAPI Math Kernel Library (oneMKL) runtime control settings

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
       - pytest -vv --pyargs mkl
 
 about:
-    home: http://github.com/IntelPython/mkl-service
+    home: https://github.com/IntelPython/mkl-service
     license: BSD-3-Clause
     license_file: LICENSE.txt
     summary: Python hooks for Intel® oneAPI Math Kernel Library (oneMKL) runtime control settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ requires-python = ">=3.10,<3.15"
 test = ["pytest"]
 
 [project.urls]
-Download = "http://github.com/IntelPython/mkl-service"
-Homepage = "http://github.com/IntelPython/mkl-service"
+Download = "https://github.com/IntelPython/mkl-service"
+Homepage = "https://github.com/IntelPython/mkl-service"
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
This PR fixes security vulnerability by changing all GitHub repository URLs from insecure HTTP to secure HTTPS and also updates project metadata in `pyproject.toml` and both conda recipe files.
