### PR TITLE
Backport gh-201

### DIFF
--- a/conda-recipe-cf/meta.yaml
+++ b/conda-recipe-cf/meta.yaml
@@ -35,10 +35,12 @@ requirements:
 
 test:
     requires:
+      - pip
       - pytest
     imports:
       - mkl
     commands:
+      - pip check
       - pytest -vv --pyargs mkl
 
 about:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: Unix"
 ]
-dependencies = ["mkl"]
+dependencies = []
 description = "Python hooks for Intel® oneAPI Math Kernel Library (oneMKL) runtime control settings"
 dynamic = ["version"]
 keywords = ["MKL"]


### PR DESCRIPTION
This PR backports gh-201 to maintenance/2.7.x branch to fix upstream issues with `mkl` runtime dep