### PR TITLE
Backport 2.7.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [2.7.2] (05/11/2026)
+
+### Fixed
+* Fixed `pip check` for environments installing `mkl-service` [gh-201](https://github.com/IntelPython/mkl-service/pull/201), broken when `mkl` was introduced as runtime dependency [gh-177](https://github.com/IntelPython/mkl-service/pull/177)
+
 ## [2.7.1] (05/08/2026)
 
 ### Changed


### PR DESCRIPTION
This PR backports changelog from 2.7.2 release fixing `pip check`