### PR TITLE
Fix macOS rpath: emit one -rpath per path instead of colon-joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Migrated the build system from `setuptools` to `meson-python`, removing `setup.py` in favor of `meson.build` [gh-174](https://github.com/IntelPython/mkl-service/pull/174)
 
 ### Fixed
+* Emit one `-rpath` linker argument per path instead of colon-joining them, so the runtime library search path is baked correctly into macOS (Mach-O) extensions [gh-222](https://github.com/IntelPython/mkl-service/pull/222)
 
 ## [2.7.2] (05/11/2026)
 

--- a/meson.build
+++ b/meson.build
@@ -35,8 +35,11 @@ if host_machine.system() != 'windows'
     else
         origin = '$ORIGIN'
     endif
-    rpath = origin / '../..' + ':' + origin / '../../..'
-    rpath_link_args = ['-Wl,-rpath,' + rpath]
+
+    rpath_link_args = [
+        '-Wl,-rpath,' + origin / '../..',
+        '-Wl,-rpath,' + origin / '../../..',
+    ]
 endif
 
 # C extension


### PR DESCRIPTION
The Meson migration gh-174 built the extensions' runtime search path by colon-joining two paths into a single `-Wl,-rpath,` argument:
```
-Wl,-rpath,$ORIGIN/../..:$ORIGIN/../../..
```

Colon-as-separator is an **ELF/Linux** convention. On macOS (Mach-O) each `-rpath` produces exactly one `LC_RPATH` load command and the string is taken **verbatim** — the colon is not a separator. As a result, macOS extensions shipped a single unusable rpath entry:
```
LC_RPATH: @loader_path/../..:@loader_path/../../..   ← no such directory
```
so `@rpath/libmkl_rt.*.dylib` could not be resolved from the baked-in rpath alone.

This PR emits one `-Wl,-rpath,` argument per path, restoring the exact per-entry behavior of the legacy `setup.py` (`runtime_library_dirs=["$ORIGIN/../..", "$ORIGIN/../../.."]`). This is correct on both Mach-O and ELF.
