### PR TITLE
Remove IS_PY3K macro and dead Python 2 init branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 * Removed the `python-gil` constraint from the conda recipes, which pinned `mkl-service` to GIL-enabled Python 3.14 builds [gh-213](https://github.com/IntelPython/mkl-service/pull/213)
+* Removed the `IS_PY3K` macro and the dead Python 2 module-init branch from `_mklinitmodule.c`, since the project requires Python 3.10+ [gh-235](https://github.com/IntelPython/mkl-service/pull/235)
 
 ## [2.8.0] (07/23/2026)
 

--- a/mkl/_mklinitmodule.c
+++ b/mkl/_mklinitmodule.c
@@ -14,11 +14,8 @@
 #undef _GNU_SOURCE
 #endif
 
-#include <Python.h>
-#if PY_MAJOR_VERSION >= 3
-#define IS_PY3K
-#endif
 #include "mkl.h"
+#include <Python.h>
 
 static struct PyMethodDef methods[] = {{NULL, NULL, 0, NULL}};
 
@@ -176,7 +173,6 @@ static MKL_SERVICE_INLINE void _set_mkl_interface(void)
     _preload_threading_layer();
 }
 
-#if defined(IS_PY3K)
 static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
                                        "mklinit",
                                        NULL,
@@ -186,10 +182,8 @@ static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
                                        NULL,
                                        NULL,
                                        NULL};
-#endif
 
 /* Initialization function for the module */
-#if defined(IS_PY3K)
 PyMODINIT_FUNC PyInit__mklinit(void)
 {
     PyObject *m;
@@ -208,10 +202,3 @@ PyMODINIT_FUNC PyInit__mklinit(void)
 
     return m;
 }
-#else
-PyMODINIT_FUNC init_mklinit(void)
-{
-    _set_mkl_interface();
-    Py_InitModule("_mklinit", methods);
-}
-#endif


### PR DESCRIPTION
## Summary

`_mklinitmodule.c` still carried a `PY_MAJOR_VERSION >= 3` check defining `IS_PY3K`, guarding the Python 3 module-init path against a Python 2 fallback (`init_mklinit` / `Py_InitModule`). Since the project requires `python >=3.10` (`requires-python = ">=3.10,<3.15"`), that check is always true and the Python 2 branch is unreachable.

This removes:
- the `IS_PY3K` macro and its `PY_MAJOR_VERSION` definition
- the `#if defined(IS_PY3K)` guards around `moduledef` and `PyInit__mklinit`
- the dead `init_mklinit` / `Py_InitModule` Python 2 branch

No functional change on any supported interpreter.
